### PR TITLE
Support lazy loading modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ speed-measure-plugin*.json
 
 # IDEs and editors
 /.idea
+/.vscode
 .project
 .classpath
 .c9/

--- a/README.md
+++ b/README.md
@@ -39,18 +39,40 @@ npm i @dashjoin/json-schema-form
 In your app module add:
 
 ```typescript
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { JsonSchemaFormModule } from '@dashjoin/json-schema-form';
 ...
 
 @NgModule({
   ...
   imports: [
+    BrowserModule,
+    BrowserAnimationsModule,
     JsonSchemaFormModule,
     ...
   ],
   ...
 }
 ```
+
+`
+Note: You need import CommonModule for nested lazy loading modules
+`
+```typescript
+import { CommonModule } from '@angular/common';
+import { JsonSchemaFormModule } from '@dashjoin/json-schema-form';
+
+@NgModule({
+  ...
+  imports: [ 
+    CommonModule, 
+    JsonSchemaFormModule, 
+    ...
+  ],
+  ...
+}
+````
 
 A small sample component:
 

--- a/angular.json
+++ b/angular.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
-  "version": 1, 
+  "version": 1,
   "newProjectRoot": "projects",
   "projects": {
     "json-schema-form": {
@@ -159,6 +159,10 @@
           }
         }
       }
-    }},
-  "defaultProject": "json-schema-form"
+    }
+  },
+  "defaultProject": "json-schema-form",
+  "cli": {
+    "analytics": false
+  }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "build:library": "ng build @dashjoin/json-schema-form",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "build:library": "ng build @dashjoin/json-schema-form",
+    "build:library": "ng build @dashjoin/json-schema-form --prod",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"

--- a/projects/dashjoin/json-schema-form/src/lib/json-schema-form.module.ts
+++ b/projects/dashjoin/json-schema-form/src/lib/json-schema-form.module.ts
@@ -44,8 +44,6 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
     MatAutocompleteModule,
     HttpClientModule,
     CommonModule,
-    BrowserAnimationsModule,
-    BrowserModule,
     MatInputModule,
     MatNativeDateModule,
     MatButtonModule,

--- a/projects/dashjoin/json-schema-form/src/lib/json-schema-form.module.ts
+++ b/projects/dashjoin/json-schema-form/src/lib/json-schema-form.module.ts
@@ -14,8 +14,6 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { HttpClientModule } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { BrowserModule } from '@angular/platform-browser';
 import { MatInputModule } from '@angular/material/input';
 import { MatNativeDateModule } from '@angular/material/core';
 import { MatButtonModule } from '@angular/material/button';

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,18 +1,21 @@
-import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
-import { AppComponent, MainComponent } from './app.component';
-import { JsonSchemaFormModule } from '@dashjoin/json-schema-form';
-import { CustomComponent } from './custom.component';
-import { SchemaEditComponent } from './schema-edit.component';
-import { AppRoutingModule } from './app-routing.module';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatCardModule } from '@angular/material/card';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+
+import { JsonSchemaFormModule } from '@dashjoin/json-schema-form';
+
+import { AppComponent, MainComponent } from './app.component';
+import { CustomComponent } from './custom.component';
+import { SchemaEditComponent } from './schema-edit.component';
+import { AppRoutingModule } from './app-routing.module';
 
 @NgModule({
   declarations: [
@@ -23,6 +26,7 @@ import { MatButtonModule } from '@angular/material/button';
   ],
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
     JsonSchemaFormModule,
     MatExpansionModule,
     MatToolbarModule,


### PR DESCRIPTION
When library is used inside lazy loading module, Angular alerts with use of core modules imports:

`
zone-evergreen.js:798 Uncaught Error: Uncaught (in promise): Error: BrowserModule has already been loaded. If you need access to common directives such as NgIf and NgFor from a lazy loaded module, import CommonModule instead.
Error: BrowserModule has already been loaded. If you need access to common directives such as NgIf and NgFor from a lazy loaded module, import CommonModule instead. 
`
It is solved by deleting BrowserModule from library module definition and using CommonModule instead.
