### PR TITLE
Prevent loadComponent invoked multiple times during init

### DIFF
--- a/projects/dashjoin/json-schema-form/src/lib/json-schema-form.component.ts
+++ b/projects/dashjoin/json-schema-form/src/lib/json-schema-form.component.ts
@@ -373,7 +373,8 @@ export class JsonSchemaFormComponent implements OnInit, OnChanges {
         this.ngOnInit();
       }
     }
-    if (changes.switch) {
+
+    if (changes.switch && !changes.switch.isFirstChange()) {
       if (this.getLayout() === 'custom') {
         this.loadComponent();
       } else {


### PR DESCRIPTION
Prevent loadComponent invoked multiple times during init.

This is related to an issue created here https://github.com/sibiraj-s/ngx-editor/pull/318. There are some errors caused during the destroy cycle. The library creates a subscription on init and destroy's it during destroy cycle. Since the loadComponent is called multiple times angular somehow skips calling `ngOnint` (possibly optimisation or bug 🤷‍♂️ ), hence the fix. since the loadComponent is called already during onInit, invoking it again is not necessary I believe. Let me know your thoughts.

The other way to fix this is manually invoking changeDetection cycle after createComponent. Which I don't think is necessary now.

```ts
componentRef.changeDetectorRef.detectChanges()
```