### PR TITLE
dashjoin/#152: add support for step attribute

### DIFF
--- a/projects/dashjoin/json-schema-form/src/lib/json-schema-form.component.html
+++ b/projects/dashjoin/json-schema-form/src/lib/json-schema-form.component.html
@@ -298,7 +298,7 @@
             <mat-label>{{label}}</mat-label>
             <input [disabled]="readOnly" [placeholder]="example()" autocomplete="off" matInput
                 [type]="getInputType(schema)" [value]="value" (input)="change($event)"
-                (focus)="getInputType(schema) === 'password' ? value = '':''">
+                [step]="getStepValue(schema)" (focus)="getInputType(schema) === 'password' ? value = '':''">
         </mat-form-field>
         <p class="error mat-typography">{{error()}}</p>
     </div>

--- a/projects/dashjoin/json-schema-form/src/lib/json-schema-form.component.ts
+++ b/projects/dashjoin/json-schema-form/src/lib/json-schema-form.component.ts
@@ -521,6 +521,20 @@ export class JsonSchemaFormComponent implements OnInit, OnChanges {
   }
 
   /**
+   * called from template in the "simple" type. Step will defaults to `any`
+   * otherwise it will use the configured value in the schema.
+   * Allows fine control over validation and increment/decrement of the input
+   * 
+   * 
+   * @param schema JSON schema object describing the property
+   * 
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-step
+   */
+  getStepValue(schema: Schema): string {
+    return schema.step ? schema.step : "any";
+  }
+
+  /**
    * event handler for object display. Catches the child component event and
    * handle it by setting the value[key].
    * Also init null objects with {}
@@ -669,6 +683,13 @@ export class JsonSchemaFormComponent implements OnInit, OnChanges {
       if (this.schema.uniqueItems) {
         if (!(new Set(this.value).size === this.value.length)) {
           return this.e('Array entries must be unique');
+        }
+      }
+      if (this.schema.step && this.schema.step != "any") {
+        const stepValue = Number.parseFloat(this.schema.step);
+        const value = Number.parseFloat(this.value);
+        if (value % stepValue != 0) {
+          return this.e(`Input is invalid for the step configured (step: ${this.schema.step})`)
         }
       }
       if (this.schema.minItems || this.schema.minItems === 0) {

--- a/projects/dashjoin/json-schema-form/src/lib/schema.ts
+++ b/projects/dashjoin/json-schema-form/src/lib/schema.ts
@@ -12,6 +12,11 @@ export interface Schema {
     type?: 'boolean' | 'string' | 'array' | 'number' | 'integer' | 'object';
 
     /**
+     * input step configuration.
+     */
+    step?: string;
+
+    /**
      * schema property reference
      */
     '$ref'?: string;


### PR DESCRIPTION
Fixes #152 

Add support for `step` configuration to be used in inputs.
If nothing is specified `any` is used.

This allows control over the validation of the input regarding the expected step, and displays a validation error if the value is not conform to the configured `step` value.